### PR TITLE
fix(demo): font (+fallback)

### DIFF
--- a/demo/public/css/base.css
+++ b/demo/public/css/base.css
@@ -30,7 +30,7 @@ body {
   margin-left: auto;
   margin-right: auto;
   max-width: 800px;
-  font-family: Montserrat;
+  font-family: Montserrat, sans-serif;
 }
 h1 {
   font-size: 3rem;
@@ -59,7 +59,7 @@ a {
 /* Search input */
 #i {
   outline: 0;
-  font-family: "Open Sans";
+  font-family: "Open Sans", sans-serif;
   border: solid 1px rgba(255, 255, 255, 0.5);
   box-shadow: 0 1px 10px rgba(0, 0, 0, 0.2), 0 2px 4px 0 rgba(0, 0, 0, 0.1);
   color: rgba(0, 0, 0, .7);
@@ -80,6 +80,7 @@ a {
   font-size: .9rem;
   text-align: right;
   -webkit-font-smoothing: antialiased;
+  font-family: Montserrat, sans-serif;
   color: rgba(255, 255, 255, 0.6);
   max-width: 800px;
 }


### PR DESCRIPTION
Today the "number of results" doesn't have a font, so it'll be in Times New Roman. 

I also added a fallback to `sans-serif` in case the Google fonts don't load.

before|after
---|---
![screen shot 2017-03-31 at 11 11 31](https://cloud.githubusercontent.com/assets/6270048/24544261/e2905a72-1602-11e7-824f-201aa91e2b94.png) | ![screen shot 2017-03-31 at 11 11 17](https://cloud.githubusercontent.com/assets/6270048/24544262/e2b836be-1602-11e7-818d-dbef781f9042.png)
